### PR TITLE
Do not crash when feed entries have no/invalid links

### DIFF
--- a/app/src/main/java/api/standalone/StandaloneNewsApi.kt
+++ b/app/src/main/java/api/standalone/StandaloneNewsApi.kt
@@ -199,7 +199,7 @@ class StandaloneNewsApi(
         id = sha256("$feedId:$title:$description"),
         feedId = feedId,
         title = title ?: "",
-        link = link.toString(),
+        link = link?.toString() ?: "",
         published = (pubDate ?: Date()).toIsoString(),
         updated = (pubDate ?: Date()).toIsoString(),
         authorName = author ?: "",

--- a/app/src/main/java/common/FragmentExt.kt
+++ b/app/src/main/java/common/FragmentExt.kt
@@ -1,6 +1,9 @@
 package common
 
+import android.content.ActivityNotFoundException
 import android.content.DialogInterface
+import android.content.Intent
+import android.net.Uri
 import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -72,6 +75,23 @@ fun Fragment.showErrorDialog(
         lifecycleScope.launchWhenResumed {
             onDismissListener?.invoke()
         }
+    }
+}
+
+fun Fragment.openLink(
+    link: String
+) {
+    try {
+        startActivity(
+            Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse(link)
+            )
+        )
+    } catch (e: ActivityNotFoundException) {
+        showErrorDialog(getString(R.string.invalid_url_s, link))
+    } catch (e: Exception) {
+        showErrorDialog(e)
     }
 }
 

--- a/app/src/main/java/entries/EntriesFragment.kt
+++ b/app/src/main/java/entries/EntriesFragment.kt
@@ -65,7 +65,7 @@ class EntriesFragment : AppFragment(), Scrollable {
                         model.openedEntry.value = item
 
                         if (feed.openEntriesInBrowser) {
-                            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(entry.link)))
+                            openLink(entry.link)
                         } else {
                             val action =
                                 EntriesFragmentDirections.actionEntriesFragmentToEntryFragment(item.id)

--- a/app/src/main/java/entry/EntryFragment.kt
+++ b/app/src/main/java/entry/EntryFragment.kt
@@ -104,15 +104,15 @@ class EntryFragment : AppFragment() {
                     summaryView.text = state.parsedContent
                     summaryView.movementMethod = LinkMovementMethod.getInstance()
                     progress.hide()
-                    fab.show()
 
-                    fab.setOnClickListener {
-                        startActivity(
-                            Intent(
-                                Intent.ACTION_VIEW,
-                                Uri.parse(state.entry.link)
-                            )
-                        )
+                    if (state.entry.link.isEmpty()) {
+                        fab.hide()
+                    } else {
+                        fab.show()
+
+                        fab.setOnClickListener {
+                            openLink(state.entry.link)
+                        }
                     }
                 }
 

--- a/app/src/main/java/feeds/FeedsFragment.kt
+++ b/app/src/main/java/feeds/FeedsFragment.kt
@@ -19,13 +19,7 @@ import co.appreactor.news.R
 import co.appreactor.news.databinding.FragmentFeedsBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
-import common.AppFragment
-import common.ListAdapterDecoration
-import common.hide
-import common.show
-import common.showDialog
-import common.showErrorDialog
-import common.showKeyboard
+import common.*
 import entries.EntriesFilter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
@@ -59,15 +53,11 @@ class FeedsFragment : AppFragment(lockDrawer = false) {
             }
 
             override fun onOpenHtmlLinkClick(feed: FeedsAdapterItem) {
-                val intent = Intent(Intent.ACTION_VIEW)
-                intent.data = Uri.parse(feed.alternateLink)
-                startActivity(intent)
+                openLink(feed.alternateLink)
             }
 
             override fun openLinkClick(feed: FeedsAdapterItem) {
-                val intent = Intent(Intent.ACTION_VIEW)
-                intent.data = Uri.parse(feed.selfLink)
-                startActivity(intent)
+                openLink(feed.selfLink)
             }
 
             override fun onRenameClick(feed: FeedsAdapterItem) {

--- a/app/src/main/java/search/SearchFragment.kt
+++ b/app/src/main/java/search/SearchFragment.kt
@@ -44,7 +44,7 @@ class SearchFragment : AppFragment() {
                     model.setRead(entry.id)
 
                     if (feed.openEntriesInBrowser) {
-                        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(entry.link)))
+                        openLink(entry.link)
                     } else {
                         val action =
                             SearchFragmentDirections.actionSearchFragmentToEntryFragment(item.id)


### PR DESCRIPTION
When a feed item has no link or has a link which no installed app can handle,
the app currently hard-crashes with a fatal
`android.content.ActivityNotFoundException: No Activity found to handle Intent`
exception.

Modified so that when a feed item has no link (which is a completely valid
use case for a RSS feed), the link floating action button is not displayed
at all, and when a link is opened, the `ActivityNotFoundException` is caught
and handled with an error dialog instead of crashing.