### PR TITLE
Upgrade WorkManager to 2.7.0 for Android 12 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ versions_timber=5.0.1
 versions_swipe_refresh=1.1.0
 versions_jsoup=1.14.2
 versions_fragment=1.3.6
-versions_work=2.6.0
+versions_work=2.7.0
 versions_feedk=0.1.1
 
 versions_junit=4.13.2


### PR DESCRIPTION
`targetSdkVersion 31` and using WorkManager 2.6.0 results in an immediate crash in Android 12 so ideally this change should be released ASAP but before that the whole app should be checked again in Android 12 as this shows targetSdkVersion is changed without actual checking of the app abilities.

Thanks