### PR TITLE
Automirror some of the icons for RTL

### DIFF
--- a/app/src/main/res/drawable/ic_baseline_arrow_back_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_arrow_back_24.xml
@@ -1,10 +1,11 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
-  <path
-      android:fillColor="@android:color/white"
-      android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z" />
 </vector>

--- a/app/src/main/res/drawable/ic_baseline_list_alt_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_list_alt_24.xml
@@ -1,6 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:autoMirrored="true"
     android:tint="?attr/colorControlNormal"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/drawable/ic_baseline_rss_feed_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_rss_feed_24.xml
@@ -1,9 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
     <path
         android:fillColor="@android:color/white"
         android:pathData="M6.18,17.82m-2.18,0a2.18,2.18 0,1 1,4.36 0a2.18,2.18 0,1 1,-4.36 0" />


### PR DESCRIPTION
Auto-mirroring icons for RTL should be done carefully, not all the non symmetric icons need flipping, for example the search icon shouldn't be flipped the far I can say. The only thing I really cared about was the back icon but visual felt better to flip the other two icons also as well, diff view is a bit complicated as used Android Studio's formatting after the edit.