### PR TITLE
Stop appbar background changes on scroll

### DIFF
--- a/app/src/main/res/layout/activity_app.xml
+++ b/app/src/main/res/layout/activity_app.xml
@@ -8,10 +8,11 @@
     android:layout_height="match_parent"
     app:elevation="0dp">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:fitsSystemWindows="true"
+        android:orientation="vertical">
 
         <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/appBarLayout"
@@ -69,8 +70,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+            android:orientation="vertical">
 
             <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/nav_host_fragment"
@@ -95,7 +95,7 @@
 
         </LinearLayout>
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </LinearLayout>
 
     <com.google.android.material.navigation.NavigationView
         android:id="@+id/navigationView"


### PR DESCRIPTION
Apparently the issue has something to do with CoordinatorLayout with
LinearLayout.

Snackbar works fine

https://user-images.githubusercontent.com/833473/142781132-14f5614e-905f-4d77-bf6a-24d8a5aed260.mov



