### PR TITLE
Add animated splash screen icon for Android 12

### DIFF
--- a/app/src/main/res/drawable/ic_animated_splash.xml
+++ b/app/src/main/res/drawable/ic_animated_splash.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:width="24dp"
+            android:height="24dp"
+            android:autoMirrored="true"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <path
+                android:fillColor="@color/launcher"
+                android:pathData="M0,0h24v24h-24z" />
+            <group
+                android:pivotX="12"
+                android:pivotY="12"
+                android:scaleX=".5"
+                android:scaleY=".5">
+                <path
+                    android:fillColor="@android:color/white"
+                    android:pathData="M19,5V19L5,19L5,5H19M20.1,3L3.9,3C3.4,3,3,3.4,3,3.9V20.1C3,20.5,3.4,21,3.9,21H20.1C20.5,21,21,20.5,21,20.1L21,3.9C21,3.4,20.5,3,20.1,3Z" />
+                <group
+                    android:name="dots"
+                    android:pivotX="8">
+                    <path
+                        android:fillColor="@android:color/white"
+                        android:pathData="M7,7H9V9L7,9ZM7,11H9V13L7,13ZM7,15H9V17L7,17Z" />
+                </group>
+                <group
+                    android:name="first_band"
+                    android:pivotX="11">
+                    <path
+                        android:fillColor="@android:color/white"
+                        android:pathData="M11,7H17V9H11L11,7Z" />
+                </group>
+                <group
+                    android:name="second_band"
+                    android:pivotX="11">
+                    <path
+                        android:fillColor="@android:color/white"
+                        android:pathData="M11,11H17V13H11V11Z" />
+                </group>
+                <group
+                    android:name="third_band"
+                    android:pivotX="11">
+                    <path
+                        android:fillColor="@android:color/white"
+                        android:pathData="M11,15H17V17H11Z" />
+                </group>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="first_band">
+        <aapt:attr name="android:animation">
+            <set android:ordering="together">
+                <objectAnimator
+                    android:duration="240"
+                    android:propertyName="scaleX"
+                    android:startOffset="320"
+                    android:valueFrom="0"
+                    android:valueTo="1.1"
+                    android:valueType="floatType" />
+                <objectAnimator
+                    android:duration="240"
+                    android:propertyName="scaleX"
+                    android:startOffset="560"
+                    android:valueFrom="1.1"
+                    android:valueTo="1"
+                    android:valueType="floatType" />
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="second_band">
+        <aapt:attr name="android:animation">
+            <set android:ordering="together">
+                <objectAnimator
+                    android:duration="240"
+                    android:propertyName="scaleX"
+                    android:startOffset="440"
+                    android:valueFrom="0"
+                    android:valueTo="1.1"
+                    android:valueType="floatType" />
+                <objectAnimator
+                    android:duration="240"
+                    android:propertyName="scaleX"
+                    android:startOffset="680"
+                    android:valueFrom="1.1"
+                    android:valueTo="1"
+                    android:valueType="floatType" />
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="third_band">
+        <aapt:attr name="android:animation">
+            <set android:ordering="together">
+                <objectAnimator
+                    android:duration="240"
+                    android:propertyName="scaleX"
+                    android:startOffset="560"
+                    android:valueFrom="0"
+                    android:valueTo="1.1"
+                    android:valueType="floatType" />
+                <objectAnimator
+                    android:duration="240"
+                    android:propertyName="scaleX"
+                    android:startOffset="800"
+                    android:valueFrom="1.1"
+                    android:valueTo="1"
+                    android:valueType="floatType" />
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -4,6 +4,10 @@
         <item name="android:statusBarColor">?colorSurface</item>
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="android:windowSplashScreenAnimatedIcon" tools:targetApi="s">
+            @drawable/ic_animated_splash
+        </item>
+        <item name="android:windowSplashScreenAnimationDuration" tools:targetApi="s">1000</item>
     </style>
 
     <style name="AppTheme" parent="BaseAppTheme">


### PR DESCRIPTION
For testing, please note that Android's own splash screen is only shown when activity is new but won't be shown if is started by Android Studio so to test, one should stop the app manually and start it again from the phone's launcher to see the animation.

https://user-images.githubusercontent.com/833473/147419431-01cbbddc-38f1-4596-89d1-41076391ec60.mov

.