### PR TITLE
Add Android 13 monochrome/themed icon support

### DIFF
--- a/app/src/main/res/drawable/ic_launcher.xml
+++ b/app/src/main/res/drawable/ic_launcher.xml
@@ -3,4 +3,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/launcher" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/drawable/ic_launcher_round.xml
+++ b/app/src/main/res/drawable/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/launcher" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
Before

<img width="208" alt="image" src="https://user-images.githubusercontent.com/833473/159184452-0c5ff587-200d-4e13-ab93-4fd0c1688d66.png">

After

<img width="243" alt="image" src="https://user-images.githubusercontent.com/833473/159184458-6f640a20-6206-404d-9fee-e47ff2997a69.png">

Needs this before test on Tiramisu/13:

<img width="259" alt="image" src="https://user-images.githubusercontent.com/833473/159184641-5ec94f29-9d64-4111-be5c-297f04bb60eb.png">
