### PR TITLE
Use kotlin-test asserters

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -150,6 +150,8 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.ext:truth:1.4.0")
     androidTestImplementation("com.google.truth:truth:1.0.1")
+    androidTestImplementation(kotlin("test"))
+    testImplementation(kotlin("test"))
 
     // Espresso dependencies
     val espressoVersion = "3.4.0"

--- a/app/src/androidTest/kotlin/sync/SyncWorkerTest.kt
+++ b/app/src/androidTest/kotlin/sync/SyncWorkerTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.test.assertIs
 
 @RunWith(AndroidJUnit4::class)
 class SyncWorkerTest {
@@ -26,6 +27,6 @@ class SyncWorkerTest {
         val workerBuilder = TestWorkerBuilder.from(targetContext, SyncWorker::class.java)
         val worker = workerBuilder.build()
         val result = worker.doWork()
-        Assert.assertTrue(result is ListenableWorker.Result.Retry)
+        assertIs<ListenableWorker.Result.Retry>(result)
     }
 }

--- a/app/src/test/kotlin/api/StandaloneNewsApiTests.kt
+++ b/app/src/test/kotlin/api/StandaloneNewsApiTests.kt
@@ -37,7 +37,7 @@ class StandaloneNewsApiTests {
 //        every { response.isSuccessful } returns false
 //        every { response.code } returns 404
 //
-//        Assert.assertThrows(Exception::class.java) {
+//        assertFails {
 //            runBlocking { api.addFeed(url) }
 //        }
 //    }

--- a/app/src/test/kotlin/db/ConfQueriesTest.kt
+++ b/app/src/test/kotlin/db/ConfQueriesTest.kt
@@ -2,9 +2,10 @@ package db
 
 import common.ConfRepository
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class ConfQueriesTest {
     private lateinit var db: ConfQueries
@@ -20,28 +21,28 @@ class ConfQueriesTest {
         val conf = db.select().executeAsOne()
         val changedConf = conf.copy(authType = "test")
         runBlocking { ConfRepository(db).save(changedConf) }
-        Assert.assertEquals(changedConf, db.select().executeAsOne())
+        assertEquals(changedConf, db.select().executeAsOne())
     }
 
     @Test
     fun `insert default`() {
         db.insertDefault()
         val conf = db.select().executeAsOne()
-        Assert.assertEquals(defaultConf(), conf)
+        assertEquals(defaultConf(), conf)
     }
 
     @Test
     fun select() {
         db.insertDefault()
         val conf = db.select().executeAsOne()
-        Assert.assertEquals(conf, db.select().executeAsOne())
+        assertEquals(conf, db.select().executeAsOne())
     }
 
     @Test
     fun `delete all`() {
         db.insertDefault()
         db.deleteAll()
-        Assert.assertNull(db.select().executeAsOneOrNull())
+        assertNull(db.select().executeAsOneOrNull())
     }
 }
 

--- a/app/src/test/kotlin/db/EntryQueriesTest.kt
+++ b/app/src/test/kotlin/db/EntryQueriesTest.kt
@@ -1,10 +1,10 @@
 package db
 
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import java.time.OffsetDateTime
 import java.util.UUID
+import kotlin.test.assertEquals
 
 class EntryQueriesTest {
 
@@ -19,7 +19,7 @@ class EntryQueriesTest {
     fun `insert or replace`() {
         val item = entry()
         db.insertOrReplace(item)
-        Assert.assertEquals(item, db.selectById(item.id).executeAsOne())
+        assertEquals(item, db.selectById(item.id).executeAsOne())
     }
 
     @Test
@@ -27,7 +27,7 @@ class EntryQueriesTest {
         val items = listOf(entry(), entry())
         items.forEach { db.insertOrReplace(it) }
 
-        Assert.assertEquals(
+        assertEquals(
             items.map { it.withoutSummary() }.reversed(),
             db.selectAll().executeAsList()
         )
@@ -41,7 +41,7 @@ class EntryQueriesTest {
             db.insertOrReplace(),
         )
 
-        Assert.assertEquals(
+        assertEquals(
             items[1],
             db.selectById(items[1].id).executeAsOneOrNull(),
         )
@@ -56,7 +56,7 @@ class EntryQueriesTest {
         db.insertOrReplace(entry().copy(feedId = feed1))
         db.insertOrReplace(entry().copy(feedId = feed2))
 
-        Assert.assertEquals(
+        assertEquals(
             1,
             db.selectByFeedId(feed2).executeAsList().size,
         )
@@ -72,7 +72,7 @@ class EntryQueriesTest {
 
         all.forEach { db.insertOrReplace(it) }
 
-        Assert.assertEquals(
+        assertEquals(
             all.filter { !it.read && !it.bookmarked }.map { it.withoutSummary() },
             db.selectByReadAndBookmarked(read = false, bookmarked = false).executeAsList(),
         )
@@ -88,7 +88,7 @@ class EntryQueriesTest {
 
         all.forEach { db.insertOrReplace(it) }
 
-        Assert.assertEquals(
+        assertEquals(
             all.filter { !it.read || it.bookmarked }.map { it.withoutSummary() }.reversed(),
             db.selectByReadOrBookmarked(read = false, bookmarked = true).executeAsList(),
         )
@@ -104,12 +104,12 @@ class EntryQueriesTest {
 
         all.forEach { db.insertOrReplace(it) }
 
-        Assert.assertEquals(
+        assertEquals(
             all.filter { it.read }.map { it.withoutSummary() }.sortedByDescending { it.published },
             db.selectByRead(true).executeAsList(),
         )
 
-        Assert.assertEquals(
+        assertEquals(
             all.filter { !it.read }.map { it.withoutSummary() }.sortedByDescending { it.published },
             db.selectByRead(false).executeAsList(),
         )
@@ -125,12 +125,12 @@ class EntryQueriesTest {
 
         all.forEach { db.insertOrReplace(it) }
 
-        Assert.assertEquals(
+        assertEquals(
             all.filter { it.readSynced }.map { it.withoutSummary() }.sortedByDescending { it.published },
             db.selectByReadSynced(true).executeAsList(),
         )
 
-        Assert.assertEquals(
+        assertEquals(
             all.filter { !it.readSynced }.map { it.withoutSummary() }.sortedByDescending { it.published },
             db.selectByReadSynced(false).executeAsList(),
         )
@@ -146,12 +146,12 @@ class EntryQueriesTest {
 
         all.forEach { db.insertOrReplace(it) }
 
-        Assert.assertEquals(
+        assertEquals(
             all.filter { it.bookmarked }.map { it.withoutSummary() }.sortedByDescending { it.published },
             db.selectByBookmarked(true).executeAsList(),
         )
 
-        Assert.assertEquals(
+        assertEquals(
             all.filter { !it.bookmarked }.map { it.withoutSummary() }.sortedByDescending { it.published },
             db.selectByBookmarked(false).executeAsList(),
         )
@@ -174,8 +174,8 @@ class EntryQueriesTest {
             updateReadByFeedId(read = true, feedId = feedId)
 
             selectAll().executeAsList().apply {
-                Assert.assertEquals(1, filter { !it.readSynced }.size)
-                Assert.assertEquals(2, filter { it.feedId == feedId && it.read }.size)
+                assertEquals(1, filter { !it.readSynced }.size)
+                assertEquals(2, filter { it.feedId == feedId && it.read }.size)
             }
         }
     }
@@ -197,8 +197,8 @@ class EntryQueriesTest {
             updateReadByBookmarked(read = true, bookmarked = bookmarked)
 
             selectAll().executeAsList().apply {
-                Assert.assertEquals(1, filterNot { it.readSynced }.size)
-                Assert.assertEquals(2, filter { it.bookmarked && it.read }.size)
+                assertEquals(1, filterNot { it.readSynced }.size)
+                assertEquals(2, filter { it.bookmarked && it.read }.size)
             }
         }
     }

--- a/app/src/test/kotlin/db/FeedQueriesTest.kt
+++ b/app/src/test/kotlin/db/FeedQueriesTest.kt
@@ -1,9 +1,10 @@
 package db
 
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class FeedQueriesTest {
 
@@ -17,35 +18,35 @@ class FeedQueriesTest {
     @Test
     fun `insert or replace`() {
         val feed = db.insertOrReplace()
-        Assert.assertEquals(feed, db.selectAll().executeAsList().single())
+        assertEquals(feed, db.selectAll().executeAsList().single())
         db.insertOrReplace(feed)
-        Assert.assertEquals(feed, db.selectAll().executeAsList().single())
+        assertEquals(feed, db.selectAll().executeAsList().single())
     }
 
     @Test
     fun `select all`() {
         val rows = listOf(db.insertOrReplace(), db.insertOrReplace(), db.insertOrReplace())
-        Assert.assertEquals(rows.sortedBy { it.title }, db.selectAll().executeAsList())
+        assertEquals(rows.sortedBy { it.title }, db.selectAll().executeAsList())
     }
 
     @Test
     fun `select by id`() {
         val row = db.insertOrReplace()
-        Assert.assertEquals(row, db.selectById(row.id).executeAsOne())
+        assertEquals(row, db.selectById(row.id).executeAsOne())
     }
 
     @Test
     fun `delete all`() {
         repeat(3) { db.insertOrReplace() }
         db.deleteAll()
-        Assert.assertTrue(db.selectAll().executeAsList().isEmpty())
+        assertTrue(db.selectAll().executeAsList().isEmpty())
     }
 
     @Test
     fun `delete by id`() {
         val rows = mutableListOf(db.insertOrReplace(), db.insertOrReplace(), db.insertOrReplace())
         db.deleteById(rows.removeAt(1).id)
-        Assert.assertEquals(rows.sortedBy { it.title }, db.selectAll().executeAsList())
+        assertEquals(rows.sortedBy { it.title }, db.selectAll().executeAsList())
     }
 }
 

--- a/app/src/test/kotlin/entries/EntriesRepositoryTests.kt
+++ b/app/src/test/kotlin/entries/EntriesRepositoryTests.kt
@@ -5,10 +5,10 @@ import com.squareup.sqldelight.runtime.coroutines.asFlow
 import com.squareup.sqldelight.runtime.coroutines.mapToList
 import db.*
 import io.mockk.*
+import kotlin.test.assertEquals
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
 import org.junit.Test
 
 class EntriesRepositoryTests {
@@ -30,7 +30,7 @@ class EntriesRepositoryTests {
             every { executeAsList() } returns entries
         }
 
-        Assert.assertEquals(entries, repository.selectAll())
+        assertEquals(entries, repository.selectAll())
 
         verify { db.selectAll() }
 
@@ -48,7 +48,7 @@ class EntriesRepositoryTests {
             every { executeAsOneOrNull() } returns entry
         }
 
-        Assert.assertEquals(entry, repository.selectById(entry.id))
+        assertEquals(entry, repository.selectById(entry.id))
 
         verify { db.selectById(entry.id) }
 
@@ -67,7 +67,7 @@ class EntriesRepositoryTests {
             every { executeAsList() } returns entries
         }
 
-        Assert.assertEquals(entries, repository.selectByFeedId(feedId))
+        assertEquals(entries, repository.selectByFeedId(feedId))
 
         verify { db.selectByFeedId(feedId) }
 
@@ -88,7 +88,7 @@ class EntriesRepositoryTests {
             every { executeAsList() } returns entries
         }
 
-        Assert.assertEquals(entries, repository.selectByReadAndBookmarked(read, bookmarked))
+        assertEquals(entries, repository.selectByReadAndBookmarked(read, bookmarked))
 
         verify { db.selectByReadAndBookmarked(read, bookmarked) }
 
@@ -112,7 +112,7 @@ class EntriesRepositoryTests {
             }
         }
 
-        Assert.assertEquals(entries, repository.selectByReadOrBookmarked(read, bookmarked).first())
+        assertEquals(entries, repository.selectByReadOrBookmarked(read, bookmarked).first())
 
         verify { db.selectByReadOrBookmarked(read, bookmarked) }
 
@@ -131,7 +131,7 @@ class EntriesRepositoryTests {
             every { executeAsList() } returns entries
         }
 
-        Assert.assertEquals(entries, repository.selectByRead(read))
+        assertEquals(entries, repository.selectByRead(read))
 
         verify { db.selectByRead(read) }
 

--- a/app/src/test/kotlin/feeds/FeedsRepositoryTests.kt
+++ b/app/src/test/kotlin/feeds/FeedsRepositoryTests.kt
@@ -10,8 +10,8 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import java.net.URI
@@ -65,7 +65,7 @@ class FeedsRepositoryTests {
             every { executeAsList() } returns feeds
         }
 
-        Assert.assertEquals(feeds, repository.selectAll())
+        assertEquals(feeds, repository.selectAll())
 
         coVerify { db.selectAll() }
 
@@ -80,7 +80,7 @@ class FeedsRepositoryTests {
             every { executeAsOneOrNull() } returns feed
         }
 
-        Assert.assertEquals(feed, repository.selectById(feed.id))
+        assertEquals(feed, repository.selectById(feed.id))
 
         verify { db.selectById(feed.id) }
 

--- a/app/src/test/kotlin/feeds/FeedsViewModelTests.kt
+++ b/app/src/test/kotlin/feeds/FeedsViewModelTests.kt
@@ -5,9 +5,9 @@ import common.ConfRepository
 import entries.EntriesRepository
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FeedsViewModelTests {

--- a/app/src/test/kotlin/opml/OpmlTests.kt
+++ b/app/src/test/kotlin/opml/OpmlTests.kt
@@ -1,11 +1,13 @@
 package opml
 
 import db.Feed
-import org.junit.Assert
 import org.junit.Test
 import java.io.InputStream
 import java.nio.charset.Charset
 import java.util.UUID
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class OpmlTests {
 
@@ -39,7 +41,7 @@ class OpmlTests {
     @Test
     fun readsSampleDocument() {
         val elements = importOpml(readFile("sample.opml"))
-        Assert.assertArrayEquals(sampleElements.toTypedArray(), elements.toTypedArray())
+        assertContentEquals(sampleElements, elements)
     }
 
     @Test
@@ -58,20 +60,20 @@ class OpmlTests {
 
         val opml = exportOpml(feeds)
         val elements = importOpml(opml)
-        Assert.assertTrue(opml.lines().size > 1)
-        Assert.assertArrayEquals(sampleElements.toTypedArray(), elements.toTypedArray())
+        assertTrue(opml.lines().size > 1)
+        assertContentEquals(sampleElements.toTypedArray(), elements.toTypedArray())
     }
 
     @Test
     fun readNestedOpml() {
         val elements = importOpml(readFile("nested.opml"))
-        Assert.assertEquals(6, elements.size)
+        assertEquals(6, elements.size)
     }
 
     @Test
     fun readsMozillaOpml() {
         val elements = importOpml(readFile("mozilla.opml"))
-        Assert.assertEquals(2, elements.size)
+        assertEquals(2, elements.size)
     }
 
     private fun readFile(path: String) = javaClass.getResourceAsStream(path)!!.readTextAndClose()

--- a/app/src/test/kotlin/podcasts/PodcastsRepositoryTests.kt
+++ b/app/src/test/kotlin/podcasts/PodcastsRepositoryTests.kt
@@ -5,9 +5,9 @@ import db.*
 import entries.EntriesRepository
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
 import org.junit.Test
 import java.util.*
+import kotlin.test.assertEquals
 
 class PodcastsRepositoryTests {
 
@@ -31,7 +31,7 @@ class PodcastsRepositoryTests {
             every { executeAsOneOrNull() } returns enclosure
         }
 
-        Assert.assertEquals(enclosure, repository.selectByEntryId(enclosure.entryId))
+        assertEquals(enclosure, repository.selectByEntryId(enclosure.entryId))
 
         verify { entryEnclosureQueries.selectByEntryId(enclosure.entryId) }
 


### PR DESCRIPTION
As it provides more Kotlin idiomatic asserters than Java asserters.

* Provides `assertIs<T>(value)` instead having to write `assertTrue(value is T)`
* Has a `assertContentEquals` which works with iterables instead requiring arrays like `assertArrayEquals`
* `assertFails` instead current `assertThrows(Exception::class.java)` which forces you to specify the type, there is a `assertFailsWith` also when a type is needed.
* Provides IDE lint when `assertEquals` can be used instead `assertTrue` and etc
