### PR TITLE
Per feed swipe actions 

### DIFF
--- a/app/src/main/kotlin/entries/EntriesFragment.kt
+++ b/app/src/main/kotlin/entries/EntriesFragment.kt
@@ -129,7 +129,7 @@ class EntriesFragment : Fragment(), OnItemReselectedListener {
     private fun initSwipeRefresh() {
         binding.swipeRefresh.apply {
             when (args.filter) {
-                is EntriesFilter.NotBookmarked -> {
+                is EntriesFilter.NotBookmarked, is EntriesFilter.BelongToFeed -> {
                     isEnabled = true
                     setOnRefreshListener { model.onPullRefresh() }
                 }

--- a/app/src/main/kotlin/entries/EntriesFragment.kt
+++ b/app/src/main/kotlin/entries/EntriesFragment.kt
@@ -373,7 +373,7 @@ class EntriesFragment : Fragment(), OnItemReselectedListener {
 
     private fun createTouchHelper(): ItemTouchHelper? {
         return when (args.filter) {
-            EntriesFilter.NotBookmarked -> {
+            EntriesFilter.NotBookmarked, is EntriesFilter.BelongToFeed -> {
                 ItemTouchHelper(object : SwipeHelper(
                     requireContext(),
                     R.drawable.ic_baseline_visibility_24,


### PR DESCRIPTION
 Closes #119
A rather simple change to add the sideways swipe functionality to the per feed view.
It also adds the pull-to-refresh to the individual feed view (but I'm unsure if further changes are needed to update the displayed content). 
