### PR TITLE
Use dynamic colors in animated splash screen icon

### DIFF
--- a/app/src/main/res/drawable/ic_animated_splash.xml
+++ b/app/src/main/res/drawable/ic_animated_splash.xml
@@ -9,7 +9,7 @@
             android:viewportWidth="24"
             android:viewportHeight="24">
             <path
-                android:fillColor="@color/launcher"
+                android:fillColor="?attr/colorPrimary"
                 android:pathData="M0,0h24v24h-24z" />
             <group
                 android:pivotX="12"
@@ -17,34 +17,34 @@
                 android:scaleX=".5"
                 android:scaleY=".5">
                 <path
-                    android:fillColor="@android:color/white"
+                    android:fillColor="?attr/colorOnPrimary"
                     android:pathData="M19,5V19L5,19L5,5H19M20.1,3L3.9,3C3.4,3,3,3.4,3,3.9V20.1C3,20.5,3.4,21,3.9,21H20.1C20.5,21,21,20.5,21,20.1L21,3.9C21,3.4,20.5,3,20.1,3Z" />
                 <group
                     android:name="dots"
                     android:pivotX="8">
                     <path
-                        android:fillColor="@android:color/white"
+                        android:fillColor="?attr/colorOnPrimary"
                         android:pathData="M7,7H9V9L7,9ZM7,11H9V13L7,13ZM7,15H9V17L7,17Z" />
                 </group>
                 <group
                     android:name="first_band"
                     android:pivotX="11">
                     <path
-                        android:fillColor="@android:color/white"
+                        android:fillColor="?attr/colorOnPrimary"
                         android:pathData="M11,7H17V9H11L11,7Z" />
                 </group>
                 <group
                     android:name="second_band"
                     android:pivotX="11">
                     <path
-                        android:fillColor="@android:color/white"
+                        android:fillColor="?attr/colorOnPrimary"
                         android:pathData="M11,11H17V13H11V11Z" />
                 </group>
                 <group
                     android:name="third_band"
                     android:pivotX="11">
                     <path
-                        android:fillColor="@android:color/white"
+                        android:fillColor="?attr/colorOnPrimary"
                         android:pathData="M11,15H17V17H11Z" />
                 </group>
             </group>


### PR DESCRIPTION
Turns blue color in animated splash screen icon to device accent derived colors,

Before:

https://user-images.githubusercontent.com/833473/231838629-375acf12-d5be-459f-9341-6138aaee713c.mov

After:

https://user-images.githubusercontent.com/833473/231838815-e8950add-a147-4111-9cf3-0e52c5d8f0df.mov

and

https://user-images.githubusercontent.com/833473/231838841-07989cfd-8c68-44a3-b7c2-fdee1decae6d.mov

